### PR TITLE
Feat(veto-frontend): VN-104: adds a main layout and the logic for navigation from side menu

### DIFF
--- a/packages/veto-frontend/src/App.tsx
+++ b/packages/veto-frontend/src/App.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Router, RouteComponentProps } from '@reach/router'
 import { ThemeProvider } from 'emotion-theming'
 import { lightTheme, GlobalStyles } from '@veriphi/veto-ui'
+import MainLayout from './layouts/MainLayout'
 import Welcome from './pages/Welcome'
 import Dashboard from './pages/Dashboard'
 import { Global, css } from '@emotion/core'
@@ -30,7 +31,7 @@ const App = () => (
     />
     <Router data-testid="Router">
       <RouterPage path="/" pageComponent={<Welcome />} />
-      <RouterPage path="/dashboard" pageComponent={<Dashboard />} />
+      <MainLayout path="/*" />
     </Router>
   </ThemeProvider>
 )

--- a/packages/veto-frontend/src/components/molecules/SideMenu/SideMenu.tsx
+++ b/packages/veto-frontend/src/components/molecules/SideMenu/SideMenu.tsx
@@ -1,0 +1,57 @@
+import React, { FunctionComponent } from 'react'
+import { Flex } from '@veriphi/veto-ui'
+import { MainLayoutLabel, MainLayoutRoute } from '../../../layouts/MainLayout/MainLayout'
+import { navigate } from '@reach/router'
+
+type MenuItemProps = {
+    label: MainLayoutLabel
+    route: MainLayoutRoute
+}
+
+const MenuItem : FunctionComponent<MenuItemProps> = ({ label, route } : MenuItemProps)  => {
+    const handleNavigate: VoidFunction = () : void => navigate(route)
+    return (
+    <div onClick={handleNavigate}>{label}</div>
+)} 
+
+type MenuConfigItem = {
+    label: MainLayoutLabel
+    route: MainLayoutRoute
+}
+
+const menuConfig : MenuConfigItem[] = [
+    { 
+        label: 'Dashboard',
+        route: '/dashboard'
+    },
+    {
+        label: 'Wallets',
+        route: '/wallets'
+    },
+    {
+        label: 'History',
+        route: '/history'
+    },
+    {
+        label: 'Explorer',
+        route: '/explorer'
+    },
+    {
+        label: 'Monitoring',
+        route: '/monitoring'
+    }
+]
+
+type Props = {
+    currentActiveMenu: MainLayoutRoute
+}
+
+const SideMenu : FunctionComponent<Props> = ({ currentActiveMenu } : Props) : JSX.Element  => {
+    return (
+        <Flex flexDirection="column" marginRight="25px">
+        {menuConfig.map((menuItemProps : MenuConfigItem) => <MenuItem {...menuItemProps} />)}
+        </Flex>
+    )
+} 
+
+export default SideMenu

--- a/packages/veto-frontend/src/components/molecules/SideMenu/SideMenu.tsx
+++ b/packages/veto-frontend/src/components/molecules/SideMenu/SideMenu.tsx
@@ -4,54 +4,55 @@ import { MainLayoutLabel, MainLayoutRoute } from '../../../layouts/MainLayout/Ma
 import { navigate } from '@reach/router'
 
 type MenuItemProps = {
-    label: MainLayoutLabel
-    route: MainLayoutRoute
+  label: MainLayoutLabel
+  route: MainLayoutRoute
 }
 
-const MenuItem : FunctionComponent<MenuItemProps> = ({ label, route } : MenuItemProps)  => {
-    const handleNavigate: VoidFunction = () : void => navigate(route)
-    return (
-    <div onClick={handleNavigate}>{label}</div>
-)} 
+const MenuItem: FunctionComponent<MenuItemProps> = ({ label, route }: MenuItemProps) => {
+  const handleNavigate: VoidFunction = (): void => navigate(route)
+  return <div onClick={handleNavigate}>{label}</div>
+}
 
 type MenuConfigItem = {
-    label: MainLayoutLabel
-    route: MainLayoutRoute
+  label: MainLayoutLabel
+  route: MainLayoutRoute
 }
 
-const menuConfig : MenuConfigItem[] = [
-    { 
-        label: 'Dashboard',
-        route: '/dashboard'
-    },
-    {
-        label: 'Wallets',
-        route: '/wallets'
-    },
-    {
-        label: 'History',
-        route: '/history'
-    },
-    {
-        label: 'Explorer',
-        route: '/explorer'
-    },
-    {
-        label: 'Monitoring',
-        route: '/monitoring'
-    }
+const menuConfig: MenuConfigItem[] = [
+  {
+    label: 'Dashboard',
+    route: '/dashboard',
+  },
+  {
+    label: 'Wallets',
+    route: '/wallets',
+  },
+  {
+    label: 'History',
+    route: '/history',
+  },
+  {
+    label: 'Explorer',
+    route: '/explorer',
+  },
+  {
+    label: 'Monitoring',
+    route: '/monitoring',
+  },
 ]
 
 type Props = {
-    currentActiveMenu: MainLayoutRoute
+  currentActiveMenu: MainLayoutRoute
 }
 
-const SideMenu : FunctionComponent<Props> = ({ currentActiveMenu } : Props) : JSX.Element  => {
-    return (
-        <Flex flexDirection="column" marginRight="25px">
-        {menuConfig.map((menuItemProps : MenuConfigItem) => <MenuItem {...menuItemProps} />)}
-        </Flex>
-    )
-} 
+const SideMenu: FunctionComponent<Props> = ({ currentActiveMenu }: Props): JSX.Element => {
+  return (
+    <Flex flexDirection="column" marginRight="25px">
+      {menuConfig.map((menuItemProps: MenuConfigItem) => (
+        <MenuItem {...menuItemProps} />
+      ))}
+    </Flex>
+  )
+}
 
 export default SideMenu

--- a/packages/veto-frontend/src/components/molecules/SideMenu/index.tsx
+++ b/packages/veto-frontend/src/components/molecules/SideMenu/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './SideMenu'

--- a/packages/veto-frontend/src/layouts/MainLayout/MainLayout.tsx
+++ b/packages/veto-frontend/src/layouts/MainLayout/MainLayout.tsx
@@ -1,0 +1,44 @@
+import React, { FunctionComponent, useState } from 'react'
+import { Flex } from '@veriphi/veto-ui'
+import { Router } from '@reach/router'
+import Dashboard from '../../pages/Dashboard'
+import Wallets from '../../pages/Wallets'
+import History from '../../pages/History'
+import Explorer from '../../pages/Explorer'
+import Monitoring from '../../pages/Monitoring'
+import SideMenu from 'components/molecules/SideMenu'
+
+export type MainLayoutLabel = 'Dashboard' | 'Wallets' | 'History' | 'Explorer' | 'Monitoring'
+export type MainLayoutRoute = '/dashboard' | '/wallets' | '/history' |'/explorer' | '/monitoring'
+
+type Props = {
+    path: string
+}
+
+const getActiveMenu = () : MainLayoutRoute => {
+    const currentPathName : string = window.location.pathname
+    if(currentPathName !== '/dashboard' || '/wallets' || '/history' || '/explorer' || '/monitoring') {
+        return '/dashboard'
+    } else {
+        return currentPathName
+    }
+}
+
+const MainLayout : FunctionComponent<Props> = ({ path }: Props) : JSX.Element => {
+    const [activeMenu] = useState<MainLayoutRoute>(getActiveMenu())
+
+    return (
+    <Flex>
+        <SideMenu currentActiveMenu={activeMenu} />
+        <Router>
+            <Dashboard path='/dashboard' />
+            <Wallets path='/wallets' />
+            <History path='/history' />
+            <Explorer path='/explorer' />
+            <Monitoring path='/monitoring' />
+        </Router>
+    </Flex >
+    )
+}
+
+export default MainLayout

--- a/packages/veto-frontend/src/layouts/MainLayout/MainLayout.tsx
+++ b/packages/veto-frontend/src/layouts/MainLayout/MainLayout.tsx
@@ -9,36 +9,36 @@ import Monitoring from '../../pages/Monitoring'
 import SideMenu from 'components/molecules/SideMenu'
 
 export type MainLayoutLabel = 'Dashboard' | 'Wallets' | 'History' | 'Explorer' | 'Monitoring'
-export type MainLayoutRoute = '/dashboard' | '/wallets' | '/history' |'/explorer' | '/monitoring'
+export type MainLayoutRoute = '/dashboard' | '/wallets' | '/history' | '/explorer' | '/monitoring'
 
 type Props = {
-    path: string
+  path: string
 }
 
-const getActiveMenu = () : MainLayoutRoute => {
-    const currentPathName : string = window.location.pathname
-    if(currentPathName !== '/dashboard' || '/wallets' || '/history' || '/explorer' || '/monitoring') {
-        return '/dashboard'
-    } else {
-        return currentPathName
-    }
+const getActiveMenu = (): MainLayoutRoute => {
+  const currentPathName: string = window.location.pathname
+  if (currentPathName !== '/dashboard' || '/wallets' || '/history' || '/explorer' || '/monitoring') {
+    return '/dashboard'
+  } else {
+    return currentPathName
+  }
 }
 
-const MainLayout : FunctionComponent<Props> = ({ path }: Props) : JSX.Element => {
-    const [activeMenu] = useState<MainLayoutRoute>(getActiveMenu())
+const MainLayout: FunctionComponent<Props> = ({ path }: Props): JSX.Element => {
+  const [activeMenu] = useState<MainLayoutRoute>(getActiveMenu())
 
-    return (
+  return (
     <Flex>
-        <SideMenu currentActiveMenu={activeMenu} />
-        <Router>
-            <Dashboard path='/dashboard' />
-            <Wallets path='/wallets' />
-            <History path='/history' />
-            <Explorer path='/explorer' />
-            <Monitoring path='/monitoring' />
-        </Router>
-    </Flex >
-    )
+      <SideMenu currentActiveMenu={activeMenu} />
+      <Router>
+        <Dashboard path="/dashboard" />
+        <Wallets path="/wallets" />
+        <History path="/history" />
+        <Explorer path="/explorer" />
+        <Monitoring path="/monitoring" />
+      </Router>
+    </Flex>
+  )
 }
 
 export default MainLayout

--- a/packages/veto-frontend/src/layouts/MainLayout/index.ts
+++ b/packages/veto-frontend/src/layouts/MainLayout/index.ts
@@ -1,0 +1,1 @@
+export { default } from './MainLayout'

--- a/packages/veto-frontend/src/pages/Dashboard/index.tsx
+++ b/packages/veto-frontend/src/pages/Dashboard/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState, FunctionComponent } from 'react'
-import { RouteComponentProps } from '@reach/router';
+import { RouteComponentProps } from '@reach/router'
 import ReceiveBTC from 'components/molecules/ReceiveBTC'
 import { Button, Modal, Text, Flex } from '@veriphi/veto-ui'
 import { faPaperPlane } from '@fortawesome/free-solid-svg-icons/faPaperPlane'
@@ -10,7 +10,7 @@ import SendBTC from 'components/molecules/SendBTC'
 
 type Status = 'idle' | 'fetchReceivingAddress' | 'showReceivingAddress' | 'constructSendingTx' | 'sending' | 'error'
 
-const Dashboard : FunctionComponent<RouteComponentProps> = () : JSX.Element => {
+const Dashboard: FunctionComponent<RouteComponentProps> = (): JSX.Element => {
   // General Page State
   const [status, setStatus] = useState<Status>('idle')
   const [error, setError] = useState('')

--- a/packages/veto-frontend/src/pages/Dashboard/index.tsx
+++ b/packages/veto-frontend/src/pages/Dashboard/index.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react'
+import React, { useState, FunctionComponent } from 'react'
+import { RouteComponentProps } from '@reach/router';
 import ReceiveBTC from 'components/molecules/ReceiveBTC'
 import { Button, Modal, Text, Flex } from '@veriphi/veto-ui'
 import { faPaperPlane } from '@fortawesome/free-solid-svg-icons/faPaperPlane'
@@ -9,7 +10,7 @@ import SendBTC from 'components/molecules/SendBTC'
 
 type Status = 'idle' | 'fetchReceivingAddress' | 'showReceivingAddress' | 'constructSendingTx' | 'sending' | 'error'
 
-export default () => {
+const Dashboard : FunctionComponent<RouteComponentProps> = () : JSX.Element => {
   // General Page State
   const [status, setStatus] = useState<Status>('idle')
   const [error, setError] = useState('')
@@ -63,3 +64,5 @@ export default () => {
     </div>
   )
 }
+
+export default Dashboard

--- a/packages/veto-frontend/src/pages/Explorer/index.tsx
+++ b/packages/veto-frontend/src/pages/Explorer/index.tsx
@@ -1,0 +1,8 @@
+import React, { FunctionComponent } from 'react'
+import { RouteComponentProps } from '@reach/router';
+
+const Explorer : FunctionComponent<RouteComponentProps> = () : JSX.Element => {
+    return <div>Explorer</div>
+}
+
+export default Explorer

--- a/packages/veto-frontend/src/pages/Explorer/index.tsx
+++ b/packages/veto-frontend/src/pages/Explorer/index.tsx
@@ -1,8 +1,8 @@
 import React, { FunctionComponent } from 'react'
-import { RouteComponentProps } from '@reach/router';
+import { RouteComponentProps } from '@reach/router'
 
-const Explorer : FunctionComponent<RouteComponentProps> = () : JSX.Element => {
-    return <div>Explorer</div>
+const Explorer: FunctionComponent<RouteComponentProps> = (): JSX.Element => {
+  return <div>Explorer</div>
 }
 
 export default Explorer

--- a/packages/veto-frontend/src/pages/History/index.tsx
+++ b/packages/veto-frontend/src/pages/History/index.tsx
@@ -1,0 +1,8 @@
+import React, { FunctionComponent } from 'react'
+import { RouteComponentProps } from '@reach/router';
+
+const History : FunctionComponent<RouteComponentProps> = () : JSX.Element => {
+    return <div>History</div>
+}
+
+export default History

--- a/packages/veto-frontend/src/pages/History/index.tsx
+++ b/packages/veto-frontend/src/pages/History/index.tsx
@@ -1,8 +1,8 @@
 import React, { FunctionComponent } from 'react'
-import { RouteComponentProps } from '@reach/router';
+import { RouteComponentProps } from '@reach/router'
 
-const History : FunctionComponent<RouteComponentProps> = () : JSX.Element => {
-    return <div>History</div>
+const History: FunctionComponent<RouteComponentProps> = (): JSX.Element => {
+  return <div>History</div>
 }
 
 export default History

--- a/packages/veto-frontend/src/pages/Monitoring/index.tsx
+++ b/packages/veto-frontend/src/pages/Monitoring/index.tsx
@@ -1,8 +1,8 @@
 import React, { FunctionComponent } from 'react'
-import { RouteComponentProps } from '@reach/router';
+import { RouteComponentProps } from '@reach/router'
 
-const Moniroting : FunctionComponent<RouteComponentProps> = () : JSX.Element => {
-    return <div>Moniroting</div>
+const Moniroting: FunctionComponent<RouteComponentProps> = (): JSX.Element => {
+  return <div>Moniroting</div>
 }
 
 export default Moniroting

--- a/packages/veto-frontend/src/pages/Monitoring/index.tsx
+++ b/packages/veto-frontend/src/pages/Monitoring/index.tsx
@@ -1,0 +1,8 @@
+import React, { FunctionComponent } from 'react'
+import { RouteComponentProps } from '@reach/router';
+
+const Moniroting : FunctionComponent<RouteComponentProps> = () : JSX.Element => {
+    return <div>Moniroting</div>
+}
+
+export default Moniroting

--- a/packages/veto-frontend/src/pages/Wallets/index.tsx
+++ b/packages/veto-frontend/src/pages/Wallets/index.tsx
@@ -1,0 +1,8 @@
+import React, { FunctionComponent } from 'react'
+import { RouteComponentProps } from '@reach/router';
+
+const Wallets : FunctionComponent<RouteComponentProps> = () : JSX.Element => {
+    return <div>Wallets</div>
+}
+
+export default Wallets

--- a/packages/veto-frontend/src/pages/Wallets/index.tsx
+++ b/packages/veto-frontend/src/pages/Wallets/index.tsx
@@ -1,8 +1,8 @@
 import React, { FunctionComponent } from 'react'
-import { RouteComponentProps } from '@reach/router';
+import { RouteComponentProps } from '@reach/router'
 
-const Wallets : FunctionComponent<RouteComponentProps> = () : JSX.Element => {
-    return <div>Wallets</div>
+const Wallets: FunctionComponent<RouteComponentProps> = (): JSX.Element => {
+  return <div>Wallets</div>
 }
 
 export default Wallets

--- a/packages/veto-frontend/src/pages/Welcome/index.tsx
+++ b/packages/veto-frontend/src/pages/Welcome/index.tsx
@@ -1,10 +1,11 @@
-import React, { SyntheticEvent } from 'react'
+import React, { SyntheticEvent, FunctionComponent } from 'react'
+import { RouteComponentProps } from '@reach/router';
 import { useInput } from '../../hooks/useInput'
 import { navigate } from '@reach/router'
 import { Flex, Text, Input, Button } from '@veriphi/veto-ui'
 import { mockPassword } from './tempdata.json'
 
-export default () => {
+const Welcome : FunctionComponent<RouteComponentProps> = () : JSX.Element => {
   const password = useInput('')
 
   const handleOnLogin = (event: SyntheticEvent) => {
@@ -42,3 +43,5 @@ export default () => {
     </Flex>
   )
 }
+
+export default Welcome

--- a/packages/veto-frontend/src/pages/Welcome/index.tsx
+++ b/packages/veto-frontend/src/pages/Welcome/index.tsx
@@ -1,11 +1,11 @@
 import React, { SyntheticEvent, FunctionComponent } from 'react'
-import { RouteComponentProps } from '@reach/router';
+import { RouteComponentProps } from '@reach/router'
 import { useInput } from '../../hooks/useInput'
 import { navigate } from '@reach/router'
 import { Flex, Text, Input, Button } from '@veriphi/veto-ui'
 import { mockPassword } from './tempdata.json'
 
-const Welcome : FunctionComponent<RouteComponentProps> = () : JSX.Element => {
+const Welcome: FunctionComponent<RouteComponentProps> = (): JSX.Element => {
   const password = useInput('')
 
   const handleOnLogin = (event: SyntheticEvent) => {


### PR DESCRIPTION
**Description**
---

- [x] adds a component taking care of rendering connected routes 
- [x] adds ability to navigate from the side menu
- [x] improves some typing where I was working

This is some preparation work for the styling to come. This is by no means a complete version of the layout but does provide the ground work to make the rest of it and apply it to all our routes

