### PR TITLE
add cyphernode swagger url for latest cyphernode api spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ Dev login
 
 #### Cyphernode
 
+[Latest cyphernode API swagger spec](https://editor.swagger.io/#/?import=https://raw.githubusercontent.com/SatoshiPortal/cyphernode/dev/doc/openapi/v0/cyphernode-api.yaml)
+
 ##### Setup cyphernode
 
 From the root of the project, run the following commands:


### PR DESCRIPTION
# Description
Discovered it was possible to add a url import param to a raw yaml file to load the latest version of any openapi doc.
👇 
https://editor.swagger.io/#/?import=https://raw.githubusercontent.com/SatoshiPortal/cyphernode/dev/doc/openapi/v0/cyphernode-api.yaml

dev branch is the most up to date cyphernode branch.