### PR TITLE
[VN-110] Remove the possibility of absolute imports

### DIFF
--- a/packages/maintenance-app/backend/tsconfig.json
+++ b/packages/maintenance-app/backend/tsconfig.json
@@ -3,7 +3,6 @@
     "target": "es2018",
     "module": "commonjs",
     "lib": ["esnext"],
-    "baseUrl": ".",
     "moduleResolution": "node",
     "strict": true,
     "allowJs": true,

--- a/packages/screen-app/tsconfig.json
+++ b/packages/screen-app/tsconfig.json
@@ -3,7 +3,6 @@
     "target": "es2018",
     "module": "commonjs",
     "lib": ["esnext"],
-    "baseUrl": ".",
     "moduleResolution": "node",
     "strict": true,
     "allowJs": true,

--- a/packages/shared/config/tsconfig.json
+++ b/packages/shared/config/tsconfig.json
@@ -3,7 +3,6 @@
     "target": "es2018",
     "module": "commonjs",
     "lib": ["esnext"],
-    "baseUrl": ".",
     "moduleResolution": "node",
     "strict": true,
     "allowJs": true,

--- a/packages/veto-app/backend/tsconfig.json
+++ b/packages/veto-app/backend/tsconfig.json
@@ -3,7 +3,6 @@
     "target": "es2018",
     "module": "commonjs",
     "lib": ["esnext"],
-    "baseUrl": ".",
     "moduleResolution": "node",
     "strict": true,
     "allowJs": true,

--- a/packages/veto-app/frontend/tsconfig.json
+++ b/packages/veto-app/frontend/tsconfig.json
@@ -15,7 +15,6 @@
     "noEmit": true,
     "noImplicitAny": false,
     "jsx": "react",
-    "baseUrl": "./src",
     "typeRoots": ["./node_modules/@types", "./src/types/"]
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,8 +13,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noImplicitAny": false,
-    "jsx": "react",
-    "baseUrl": "./packages/"
+    "jsx": "react"
   },
   "exclude": ["node_modules"],
   "include": ["**/*.ts", "**/*.tsx"]


### PR DESCRIPTION
# Description
During the last meeting we collectively decided to disallow absolute imports.
Jenkins was having problems with them and as a group we didn't see a benefit to having them anyways.
Easy choice.

### What was done

I removed all instances of `baseUrl` in all `tsconfigs` across the project and ran everything to make sure no absolute imports were being used anywhere.